### PR TITLE
Update example to use COPY instead of ADD

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ENV PORT=5000
 
 ENV MIX_ENV=prod
 
-ADD yourapp.tar.gz ./
+COPY yourapp.tar.gz ./
 RUN tar -xzvf yourapp.tar.gz
 
 USER default


### PR DESCRIPTION
According to the Docker docs:

> If <src> is a local tar archive in a recognized compression format (identity,
  gzip, bzip2 or xz) then it is unpacked as a directory. Resources from remote
  URLs are not decompressed...

https://docs.docker.com/engine/reference/builder/#add

This means that the README.md should just have the ADD command. I think using
COPY and tar is more explicit though.