### PR TITLE
fix(readme): Updates prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To boot straight to a prompt in the image:
 
 ```
 $ docker run --rm -it --user=root bitwalker/alpine-elixir iex
-Erlang/OTP 19 [erts-8.0.1] [source] [64-bit] [async-threads:10] [hipe] [kernel-poll:false]
+Erlang/OTP 20 [erts-9.1.5] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]
 
 Interactive Elixir (1.5.2) - press Ctrl+C to exit (type h() ENTER for help)
 iex(1)>


### PR DESCRIPTION
When running the example to boot straight into a prompt, the documentation shows an outdated `Erlang/OTP 19`.

This PR updates the output to what shows when you run the example.