### PR TITLE
Use Erlang 20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-erlang:20.1
+FROM bitwalker/alpine-erlang:20.2
 
 MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 
@@ -6,7 +6,7 @@ MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2017-10-01 \
+ENV REFRESHED_AT=2017-12-18 \
     ELIXIR_VERSION=v1.5.2
 
 WORKDIR /tmp/elixir-build


### PR DESCRIPTION
At the risk of stating the obvious, this requires https://github.com/bitwalker/alpine-erlang/pull/21 to be merged first.