### PR TITLE
Add support for Elixir v1.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ LABEL maintainer="Paul Schoenfelder <paulschoenfelder@gmail.com>"
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2018-11-03 \
-    ELIXIR_VERSION=v1.7.4
+ENV REFRESHED_AT=2019-01-05 \
+    ELIXIR_VERSION=v1.8.0
 
 WORKDIR /tmp/elixir-build
 


### PR DESCRIPTION
Elixir v1.8.0 is out!

- https://github.com/elixir-lang/elixir/tree/v1.8.0
- https://elixir-lang.org/blog/2019/01/14/elixir-v1-8-0-released/