### PR TITLE
Bump erlang 22.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-erlang:21.3.8
+FROM bitwalker/alpine-erlang:22.0.4
 
 LABEL maintainer="Paul Schoenfelder <paulschoenfelder@gmail.com>"
 
@@ -6,7 +6,7 @@ LABEL maintainer="Paul Schoenfelder <paulschoenfelder@gmail.com>"
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2019-05-07 \
+ENV REFRESHED_AT=2019-06-19 \
     ELIXIR_VERSION=v1.8.1
 
 WORKDIR /tmp/elixir-build


### PR DESCRIPTION
@bitwalker Is a transparent bump from OTP 21 to 22 in the elixir image ok?