### PR TITLE
fix release file name accordint to elixir 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ ENV PORT=5000
 
 ENV MIX_ENV=prod
 
-COPY yourapp.tar.gz ./
-RUN tar -xzvf yourapp.tar.gz
+COPY yourapp ./
 
 USER default
 


### PR DESCRIPTION
In Elixir 1.9 binary file is created at _build/prod/rel/YOURAPP/bin/

````
Generated yourapp app
* assembling yourapp-1.0.0 on MIX_ENV=prod

Release created at _build/prod/rel/yourapp!

    # To start your system
    _build/prod/rel/yourapp/bin/yourapp start

Once the release is running:

    # To connect to it remotely
    _build/prod/rel/yourapp/bin/yourapp remote

    # To stop it gracefully (you may also send SIGINT/SIGTERM)
    _build/prod/rel/yourapp/bin/yourapp stop

To list all commands:

    _build/prod/rel/yourapp/bin/yourapp
````