### PR TITLE
Update to Erlang 22.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-erlang:22.2.1
+FROM bitwalker/alpine-erlang:22.2.2
 
 MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 
@@ -6,7 +6,7 @@ MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2020-01-09 \
+ENV REFRESHED_AT=2020-01-15 \
     ELIXIR_VERSION=v1.9.4 \
     MIX_HOME=/opt/mix \
     HEX_HOME=/opt/hex


### PR DESCRIPTION
The `alpine-erlang` seems to be updated to `22.2.2` and the alpine version there is also updated to `3.11.2`, so I think it would be nice to update this image as well.