### PR TITLE
Enable qemu build for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN \
       make && \
     git clone https://github.com/elixir-lang/elixir --depth 1 --branch $ELIXIR_VERSION && \
     cd elixir && \
+    if [ ! -d /usr/local/sbin ]; then ln -s /usr/local/bin /usr/local/sbin; fi && \
     make && make install && \
     mkdir -p ${HEX_HOME} && \
     mix local.hex --force && \


### PR DESCRIPTION
Building image for platform arm64 (or multi-platform) on a amd64 computer (so, using qemu through buildkit) fails on make for elixir step, because -for some unknown reason to me- binaries (erl, escript, etc) are expected to be on /usr/local/sbin instead where they really are (/usr/local/bin).

```
#0 104.0 Recompile: src/elixir_bitstring
#0 105.0 Recompile: src/elixir_aliases
#0 105.3 Recompile: src/elixir
#0 106.2 Error while loading /usr/local/sbin/escript: No such file or directory
#0 106.2 make: *** [Makefile:102: lib/elixir/ebin/elixir.app] Error 1
```
With this workaround the image can be built for ARM64.

You can reproduce the issue by running "make build" on any amd64 computer, but I guess you already know it, since the GitHub action configured only builds and publish AMD64 version.
