### PR TITLE
GitHub actions cache deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
 
     - name: Cache Docker Layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: /tmp/buildx

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= `cat VERSION | grep elixir | cut -d' ' -f2`
 ERLANG_VERSION ?= `cat VERSION | grep erlang | cut -d' ' -f2`
 MAJ_VERSION := $(shell echo $(VERSION) | sed 's/\([0-9][0-9]*\)\.\([0-9][0-9]*\)\(\.[0-9][0-9]*\)*/\1/')
 MIN_VERSION := $(shell echo $(VERSION) | sed 's/\([0-9][0-9]*\)\.\([0-9][0-9]*\)\(\.[0-9][0-9]*\)*/\1.\2/')
-IMAGE_NAME ?= bitwalker/alpine-elixir
+IMAGE_NAME ?= utrustdev/alpine-elixir
 XDG_CACHE_HOME ?= /tmp
 BUILDX_CACHE_DIR ?= $(XDG_CACHE_HOME)/buildx
 

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-elixir: 1.12.3
-erlang: 22.3
+elixir: 1.14.0
+erlang: 24.3.4

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 elixir: 1.12.3
-erlang: 24.0.6
+erlang: 22.3

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 elixir: 1.14.0
-erlang: 25.0.4
+erlang: 24.3.4


### PR DESCRIPTION
Github is deprecating the actions/cache v1 and v2 starting February 2025
the new versions are backwards compatible and no issues are expected

more info here:
https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/
https://github.com/actions/cache/discussions/1510